### PR TITLE
Improve/eliminating providers warning

### DIFF
--- a/ghe/providers.tf
+++ b/ghe/providers.tf
@@ -1,5 +1,13 @@
+terraform {
+  required_providers {
+    github = {
+      source = "hashicorp/github"
+      version = "3.0.0"
+    }
+  }
+}
+
 provider "github" {
   token        = var.ghe_token
   organization = var.ghe_organization
-  version      = "3.0.0"
 }

--- a/tfe/providers.tf
+++ b/tfe/providers.tf
@@ -1,11 +1,22 @@
+terraform {
+  required_providers {
+    github = {
+      source = "hashicorp/github"
+      version = "3.0.0"
+    }
+    tfe = {
+      source = "hashicorp/tfe"
+      version = "0.16.2"
+    }
+  }
+}
+
 provider "tfe" {
   hostname = var.tfe_hostname
   token    = var.tfe_token
-  version  = "0.16.2"
 }
 
 provider "github" {
   token        = var.ghe_token
   organization = var.tfe_org_name
-  version      = "3.0.0"
 }


### PR DESCRIPTION
Eliminating provider warning messages (like this):

[on providers.tf line 4, in provider "tfe":
   4:   version  = [4m"0.16.2"[0m

Terraform 0.13 and earlier allowed provider version constraints inside the
provider configuration block, but that is now deprecated and will be removed
in a future version of Terraform. To silence this warning, move the provider
version constraint into the required_providers block.
